### PR TITLE
Update seafile-client-3.0.4.ebuild

### DIFF
--- a/net-misc/seafile-client/seafile-client-3.0.4.ebuild
+++ b/net-misc/seafile-client/seafile-client-3.0.4.ebuild
@@ -14,7 +14,7 @@ LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~x86"
 
-DEPEND=">=net-misc/seafile-${PV}[client] dev-libs/jansson"
+DEPEND=">=net-misc/seafile-${PV}[client] dev-libs/jansson >=dev-qt/qtcore-4.8.5"
 
 RDEPEND=""
 


### PR DESCRIPTION
The cmake buildstep will fail when qt is not installed, adding qtcore to buildtime depends.
Tested with qtcore-4.8.5-r2.
Might work with lower versions also.